### PR TITLE
Remove ES6 syntax

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,16 +1,16 @@
 const url = require('url')
 
-const serialize = (obj) => {
+function serialize (obj) {
   const json = JSON.stringify(obj)
   return new Buffer(json).toString('base64')
 }
 
-const parse = (str) => {
+function parse (str) {
   const json = new Buffer(str, 'base64').toString('utf8')
   return JSON.parse(json)
 }
 
-module.exports = (req, key) => {
+module.exports = function (req, key) {
   key = key || 'data'
 
   const query = url.parse(req.url, true).query

--- a/index.js
+++ b/index.js
@@ -1,19 +1,19 @@
-const url = require('url')
+var url = require('url')
 
 function serialize (obj) {
-  const json = JSON.stringify(obj)
+  var json = JSON.stringify(obj)
   return new Buffer(json).toString('base64')
 }
 
 function parse (str) {
-  const json = new Buffer(str, 'base64').toString('utf8')
+  var json = new Buffer(str, 'base64').toString('utf8')
   return JSON.parse(json)
 }
 
 module.exports = function (req, key) {
   key = key || 'data'
 
-  const query = url.parse(req.url, true).query
+  var query = url.parse(req.url, true).query
   return parse(query[key])
 }
 


### PR DESCRIPTION
We use this in a browser env that doesn't support ES6 arrow functions (yet). We either need to transpile this module or just leave it as ES5 syntax. Moving this (back) to ES5 was much less work.